### PR TITLE
Strip release binary and optimize for size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,5 @@ panic = "abort"
 panic = "abort"
 codegen-units = 1
 lto = "fat"
-debug = 1
+strip = true
+opt-level = "s"


### PR DESCRIPTION
This takes the `cargo build --release` output on my machine from 488_240 bytes to 63_344 bytes.

Most of the gain is in strip. opt-level 3 (default for release) instead of "s" makes an about 85k binary.

Notes:
- You probably had `debug = 1` in there for a reason, but sending this just in case it was an oversight.
- I didn't benchmark if opt-level="s" is slower than opt-level=3. My intuition says all the time is spent in syscalls so we get "smaller" for free, but guessing about perf is a great way to be wrong, so maybe you don't want this part either.

