### PR TITLE
feat: Support -h to humanize file sizes

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -32,6 +32,7 @@ pub struct App {
     pub print_owner: bool,
     pub print_group: bool,
     pub color: Color,
+    pub humanize: bool,
 
     pub args: Vec<CStr<'static>>,
 
@@ -137,6 +138,7 @@ impl App {
             etc_group: &[],
             needs_details: false,
             tzinfo: None,
+            humanize: false,
         };
 
         for arg in raw_args.skip(1) {
@@ -220,6 +222,9 @@ impl App {
                 b'g' => {
                     app.display_mode = DisplayMode::Long;
                     app.print_owner = false;
+                }
+                b'h' => {
+                    app.humanize = true;
                 }
                 b'i' => {
                     app.print_inode = true;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,7 @@
 #![no_std]
 #![no_main]
+#![allow(internal_features)]
+#![feature(core_intrinsics)]
 
 extern crate alloc;
 


### PR DESCRIPTION
This is GNU ls not standard ls, but it is widespread and I find it very useful.

Implementation notes:
- The size is actually a ceiling, not a round. It is the smallest size in which the file will fit, so 1025 bytes is 1.1K not 1K.
- Instead of measuring how big the size will be as a string we always use a size of 4 for speed. This means occasionally there are 2 spaces. I don't find it noticeable.
- The stabilized `ceil` function is in `std` so we can't use it. It is a single line that calls the intrinsic, so we use that directly.