### PR TITLE
don't print "OS Error -1" on unrecognized options

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -278,7 +278,7 @@ impl App {
         }
 
         if !args_valid {
-            return Err(Error(-1));
+            exit(1);
         }
 
         if print_version {


### PR DESCRIPTION
before:
```
; fls -h
invalid option 'h'
Error: OS Error -1
```

after:
```
; fls -h
invalid option 'h'
```