### PR TITLE
don't print spaces from the last entry to the newline

### DIFF
--- a/src/output.rs
+++ b/src/output.rs
@@ -327,6 +327,11 @@ pub fn write_grid(
             app.out.style(*style);
             print!(app, e.name(), suffix.map(|s| (White, s)));
 
+            // don't pad out spaces from here until the newline
+            if c + 1 == widths.len() {
+                break;
+            }
+
             for _ in 0..(width - name_len) {
                 app.out.push(b' ');
             }


### PR DESCRIPTION
before:
```
valgrind-3.21.0.tar.bz2
vesktop_1.5.2_amd64.deb
vimium-options(1).json
vimium-options.json
```

after:
```
valgrind-3.21.0.tar.bz2
vesktop_1.5.2_amd64.deb
vimium-options(1).json
vimium-options.json
```

this appeared in the terminal as an extra blank line between each entry, except for the very longest entries.

--- 

fascinating, github has removed the trailing spaces. here is a screenshot: 
![image](https://github.com/user-attachments/assets/3a580a52-1c63-49bc-980e-0c7cfd4d4a34)
