### PR TITLE
Address the clippy lint also remove clippy from CI

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -13,7 +13,6 @@ function group {
 if [[ "$1" == "style" ]]
 then
     group cargo fmt --check
-    group cargo clippy -- -Dclippy::all
 else
     group cargo build
     group cargo build --release

--- a/src/output.rs
+++ b/src/output.rs
@@ -245,7 +245,7 @@ pub fn write_grid(
     let mut cursors = Vec::with_capacity(max_possible_columns - 1);
 
     for i in 2..=max_possible_columns {
-        layouts.extend(core::iter::repeat(0).take(i));
+        layouts.extend(core::iter::repeat_n(0, i));
         // current position, increments left until we move to the next column
         let rows = entries.len().div_ceil(i);
         cursors.push(LayoutCursor {


### PR DESCRIPTION
Running clippy in CI like this seems like a gate against mistakes but mostly it just causes CI to be broken on the default branch if the repo goes idle.