### PR TITLE
Make the happy path (no arguments) even more efficient

### DIFF
--- a/src/output.rs
+++ b/src/output.rs
@@ -441,7 +441,6 @@ impl Writable for &[u8] {
 
 impl<const N: usize> Writable for &[u8; N] {
     fn write(&self, out: &mut OutputBuffer) {
-        #[allow(clippy::explicit_auto_deref)] // Invalid suggestion
         out.write(*self);
     }
 }
@@ -526,7 +525,7 @@ where
 }
 
 pub struct OutputBuffer {
-    buf: [u8; 4096],
+    buf: [u8; Self::BUF_LEN],
     buf_used: usize,
     style: Style,
     fd: i32,
@@ -534,9 +533,11 @@ pub struct OutputBuffer {
 }
 
 impl OutputBuffer {
-    pub fn to_fd(fd: libc::c_int) -> Self {
+    const BUF_LEN: usize = 1024;
+
+    pub const fn to_fd(fd: libc::c_int) -> Self {
         Self {
-            buf: [0u8; 4096],
+            buf: [0u8; Self::BUF_LEN],
             buf_used: 0,
             style: Style::Reset,
             color: true,
@@ -556,7 +557,7 @@ impl OutputBuffer {
     }
 
     #[inline(never)]
-    pub fn flush(&mut self) -> &mut [u8; 4096] {
+    pub fn flush(&mut self) -> &mut [u8; Self::BUF_LEN] {
         write_all(&self.buf[..self.buf_used], self.fd);
         self.buf_used = 0;
         &mut self.buf


### PR DESCRIPTION
There are two primary changes here (and some random cleanup).

The slowest part of the super happy path where we run `fls -1` on a directory with not very many entries is allocation and page faults.

The more sensible change in here is just reducing allocation along that code path. We can dodge some allocations by changing `App` so it doesn't store CLI arguments in multiple `Vec`s and tweaking a lot of argument handling to try to not make a lot of passes over the arguments. We still need to do two related to handling `-H` and `-L` but I think at least one of those is buggy anyway.

The weirder changes in here are about reducing page faults from constructing an `App`. That struct is _huge_ so we really need to not move it around at all. Initializing a local from an associated const then calling a method to load CLI arguments into it makes that happen. It's a bit sketchy in terms of type safety, but I think the God Object deserves some leeway.